### PR TITLE
Feature/add trustarc code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 ## Introduction
 
-Simple Wordpress Plugin developed by the Northeastern University ITS Web Solutions team. Loads the latest version of [kernl(ui) Global Elements](https://northeastern.netlify.app/pattern-library/page-chrome/global-elements/) to your website.
+Simple Wordpress Plugin developed by the Northeastern University ITS Web Solutions team. Loads the latest version of [kernl(ui) Global Elements](https://northeastern.netlify.app/pattern-library/page-chrome/global-elements/) to your website, plus the code for the [TrustArc](https://trustarc.com/) cookie consent manager.
 
 The global elements package includes a few elements that should be included on almost all Northeastern sites. They have dynamic content and fixed designs for consistency across sites.
 
 [Learn more about the kernl(ui) design system](https://northeastern.netlify.app/)
+
+TrustArc allows users to set their cookie preferences, and is now required on all Northestern University websites.
 
 ## Requirements
 - **Global Header.** In order for the global header to display, the active theme must support a call to `wp_body_open()` after the opening `<body>` tag:
@@ -23,3 +25,4 @@ The global elements package includes a few elements that should be included on a
 1. Download repository as a `.zip` file on GitHub
 2. Upload the `.zip` file to the WordPress site's plugins
 3. Activate the new Plugin once it has finished uploading
+4. If you need to disable this plugin adding either the global header, footer, or TrustArc code, you can do so from the settings page for this plugin in wp-admin.

--- a/nu_global_elements.php
+++ b/nu_global_elements.php
@@ -2,49 +2,236 @@
 /* 
 Plugin Name: Northeastern Global Elements
 Plugin URI: https://northeastern.netlify.app/pattern-library/page-chrome/global-elements/
-Description: Inserts the Northeastern University global header and footer. Requires wp_body_open() under the body tag.
+Description: Inserts the Northeastern University global header, footer, and TrustArc cookie consent manager. Requires wp_body_open() under the body tag to display the global header.
 Author: Northeastern University ITS Web Solutions
 Author URI: https://its.northeastern.edu
-Version: 1.1.0
+Version: 1.2.0
 */ 
 
 /** 
- * Include global elements CSS, kernl UI and javascript from CDN
+ * Get options values for plugin
  */
-add_action('wp_head', function() {
 
-    echo '
-        <link rel="stylesheet" href="https://global-packages.cdn.northeastern.edu/global-elements/dist/css/index.css">
-        <script src="https://global-packages.cdn.northeastern.edu/global-elements/dist/js/index.umd.js"></script>
-        <script src="https://global-packages.cdn.northeastern.edu/kernl-ui/dist/js/index.umd.js" defer></script>
-        ';
-
-});
+$nu_global_elements_options = get_option( 'nu_global_elements_option_name' );
 
 /** 
- * Include the global NU header
+ * Include global elements CSS, kernl UI and javascript from CDN, if both header and footer are not disabled in options
+ */
+if (!(isset($nu_global_elements_options['disable_global_header']) && isset($nu_global_elements_options['disable_global_footer']))){
+    add_action('wp_head', function() {
+
+        echo '
+            <link rel="stylesheet" href="https://global-packages.cdn.northeastern.edu/global-elements/dist/css/index.css">
+            <script src="https://global-packages.cdn.northeastern.edu/global-elements/dist/js/index.umd.js"></script>
+            <script src="https://global-packages.cdn.northeastern.edu/kernl-ui/dist/js/index.umd.js" defer></script>
+            ';
+
+    });
+}
+
+/** 
+ * Include the global NU header, if it is not disabled in the options
  * 
  * NOTE: There must be a wp_body_open() statement under the <body> tag, 
  * most likely in header.php of the theme. 
  */
-add_action('wp_body_open', function() {
+if (!isset($nu_global_elements_options['disable_global_header'])){
+        add_action('wp_body_open', function() {
 
-    echo '<div
-            x-data="NUGlobalElements.header({
-                wordmark: true
-            })"
-            x-init="init()"
-            style="height: 48px; background-color: black"
-        ></div>';
+        echo '<div
+                x-data="NUGlobalElements.header({
+                    wordmark: true
+                })"
+                x-init="init()"
+                style="height: 48px; background-color: black"
+            ></div>';
 
-}, 10);
+    }, 10);
+}
 
 /** 
- * Include the global NU footer
+ * Include the global NU footer, if it is not disabled in the options
  */
-add_action('wp_footer', function() {
+if (!isset($nu_global_elements_options['disable_global_footer'])){
+    add_action('wp_footer', function() {
 
-    echo '<div x-data="NUGlobalElements.footer()" x-init="init()"></div>';
+        echo '<div x-data="NUGlobalElements.footer()" x-init="init()"></div>';
 
-});
+    });
+}
 
+/** 
+ * Include TrustArc, if it is not disabled in the options
+ */
+
+ if (!isset($nu_global_elements_options['disable_trustarc'])){
+    add_action('wp_head', function() {
+
+        echo '
+            <script src="https://consent.trustarc.com/autoblockasset/core.min.js?domain=northeastern-test.edu"></script>
+            <script src="https://consent.trustarc.com/autoblockoptout?domain=northeastern-test.edu"></script>
+            ';
+    });
+
+    add_action('wp_footer', function() {
+
+        echo '
+            <div id="consent_blackbar"></div>
+            <div id="teconsent"></div>
+            <script async="async" src="https://consent.trustarc.com/notice?domain=northeastern-test.edu&c=teconsent&js=nj&noticeType=bb&text=true&gtm=1"></script>
+            ';
+    });
+}
+
+
+/**
+ * Create plugin settings/options menu item, page and fields
+ * 
+ * Retrieve options values with:
+ * $nu_global_elements_options = get_option( 'nu_global_elements_option_name' ); // Array of All Options
+ * $disable_global_header = $nu_global_elements_options['disable_global_header']; // Disable Global Header
+ * $disable_global_footer = $nu_global_elements_options['disable_global_footer']; // Disable Global Footer
+ * $disable_trustarc = $nu_global_elements_options['disable_trustarc']; // Disable TrustArc
+ */
+
+ class NUGlobalElements {
+	private $nu_global_elements_options;
+
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'nu_global_elements_add_plugin_page' ) );
+		add_action( 'admin_init', array( $this, 'nu_global_elements_page_init' ) );
+	}
+
+	public function nu_global_elements_add_plugin_page() {
+		add_menu_page(
+			'NU Global Elements', // page_title
+			'NU Global Elements', // menu_title
+			'manage_options', // capability
+			'nu-global-elements', // menu_slug
+			array( $this, 'nu_global_elements_create_admin_page' ), // function
+			'dashicons-admin-generic', // icon_url
+			99 // position
+		);
+	}
+
+	public function nu_global_elements_create_admin_page() {
+		$this->nu_global_elements_options = get_option( 'nu_global_elements_option_name' ); ?>
+
+		<div class="wrap">
+			<h2>NU Global Elements</h2>
+			<p>If you already display these elements via a method other than this plugin, you may use these options to avoid displaying them twice.</p>
+			<?php settings_errors(); ?>
+
+			<form method="post" action="options.php">
+				<?php
+					settings_fields( 'nu_global_elements_option_group' );
+					do_settings_sections( 'nu-global-elements-admin' );
+					submit_button();
+				?>
+			</form>
+		</div>
+	<?php }
+
+	public function nu_global_elements_page_init() {
+		register_setting(
+			'nu_global_elements_option_group', // option_group
+			'nu_global_elements_option_name', // option_name
+			array( $this, 'nu_global_elements_sanitize' ) // sanitize_callback
+		);
+
+		add_settings_section(
+			'nu_global_elements_setting_section', // id
+			'Settings', // title
+			array( $this, 'nu_global_elements_section_info' ), // callback
+			'nu-global-elements-admin' // page
+		);
+
+		add_settings_field(
+			'disable_global_header', // id
+			'Disable Global Header', // title
+			array( $this, 'disable_global_header_callback' ), // callback
+			'nu-global-elements-admin', // page
+			'nu_global_elements_setting_section' // section
+		);
+
+		add_settings_field(
+			'disable_global_footer', // id
+			'Disable Global Footer', // title
+			array( $this, 'disable_global_footer_callback' ), // callback
+			'nu-global-elements-admin', // page
+			'nu_global_elements_setting_section' // section
+		);
+
+		add_settings_field(
+			'disable_trustarc', // id
+			'Disable TrustArc Cookie Consent Manager', // title
+			array( $this, 'disable_trustarc_callback' ), // callback
+			'nu-global-elements-admin', // page
+			'nu_global_elements_setting_section' // section
+		);
+	}
+
+	public function nu_global_elements_sanitize($input) {
+		$sanitary_values = array();
+		if ( isset( $input['disable_global_header'] ) ) {
+			$sanitary_values['disable_global_header'] = $input['disable_global_header'];
+		}
+
+		if ( isset( $input['disable_global_footer'] ) ) {
+			$sanitary_values['disable_global_footer'] = $input['disable_global_footer'];
+		}
+
+		if ( isset( $input['disable_trustarc'] ) ) {
+			$sanitary_values['disable_trustarc'] = $input['disable_trustarc'];
+		}
+
+		return $sanitary_values;
+	}
+
+	public function nu_global_elements_section_info() {
+		
+	}
+
+	public function disable_global_header_callback() {
+		printf(
+			'<input type="checkbox" name="nu_global_elements_option_name[disable_global_header]" id="disable_global_header" value="disable_global_header" %s>',
+			( isset( $this->nu_global_elements_options['disable_global_header'] ) && $this->nu_global_elements_options['disable_global_header'] === 'disable_global_header' ) ? 'checked' : ''
+		);
+	}
+
+	public function disable_global_footer_callback() {
+		printf(
+			'<input type="checkbox" name="nu_global_elements_option_name[disable_global_footer]" id="disable_global_footer" value="disable_global_footer" %s>',
+			( isset( $this->nu_global_elements_options['disable_global_footer'] ) && $this->nu_global_elements_options['disable_global_footer'] === 'disable_global_footer' ) ? 'checked' : ''
+		);
+	}
+
+	public function disable_trustarc_callback() {
+		printf(
+			'<input type="checkbox" name="nu_global_elements_option_name[disable_trustarc]" id="disable_trustarc" value="disable_trustarc" %s>',
+			( isset( $this->nu_global_elements_options['disable_trustarc'] ) && $this->nu_global_elements_options['disable_trustarc'] === 'disable_trustarc' ) ? 'checked' : ''
+		);
+	}
+
+}
+if ( is_admin() )
+	$nu_global_elements = new NUGlobalElements();
+
+
+add_filter( 'plugin_action_links_global-elements-wordpress/nu_global_elements.php', 'nu_global_elements_link' );
+function nu_global_elements_link( $links ) {
+    // Build and escape the URL.
+    $url = esc_url( add_query_arg(
+        'page',
+        'nu-global-elements',
+        get_admin_url() . 'admin.php'
+    ) );
+    // Create the link.
+    $settings_link = "<a href='$url'>" . __( 'Settings' ) . '</a>';
+    // Adds the link to the end of the array.
+    array_push(
+        $links,
+        $settings_link
+    );
+    return $links;
+}

--- a/nu_global_elements.php
+++ b/nu_global_elements.php
@@ -65,21 +65,9 @@ if (!isset($nu_global_elements_options['disable_global_footer'])){
  */
 
  if (!isset($nu_global_elements_options['disable_trustarc'])){
-    add_action('wp_head', function() {
-
-        echo '
-            <script src="https://consent.trustarc.com/autoblockasset/core.min.js?domain=northeastern.edu"></script>
-            <script src="https://consent.trustarc.com/autoblockoptout?domain=northeastern.edu"></script>
-            ';
-    });
-
     add_action('wp_footer', function() {
 
-        echo '
-            <div id="consent_blackbar"></div>
-            <div id="teconsent"></div>
-            <script async="async" src="https://consent.trustarc.com/notice?domain=northeastern.edu&c=teconsent&js=nj&noticeType=bb&text=true&gtm=1"></script>
-            ';
+        echo '<div x-data="NUGlobalElements.trustarc()" x-init="init()"></div>';
     });
 }
 

--- a/nu_global_elements.php
+++ b/nu_global_elements.php
@@ -68,8 +68,8 @@ if (!isset($nu_global_elements_options['disable_global_footer'])){
     add_action('wp_head', function() {
 
         echo '
-            <script src="https://consent.trustarc.com/autoblockasset/core.min.js?domain=northeastern-test.edu"></script>
-            <script src="https://consent.trustarc.com/autoblockoptout?domain=northeastern-test.edu"></script>
+            <script src="https://consent.trustarc.com/autoblockasset/core.min.js?domain=northeastern.edu"></script>
+            <script src="https://consent.trustarc.com/autoblockoptout?domain=northeastern.edu"></script>
             ';
     });
 
@@ -78,7 +78,7 @@ if (!isset($nu_global_elements_options['disable_global_footer'])){
         echo '
             <div id="consent_blackbar"></div>
             <div id="teconsent"></div>
-            <script async="async" src="https://consent.trustarc.com/notice?domain=northeastern-test.edu&c=teconsent&js=nj&noticeType=bb&text=true&gtm=1"></script>
+            <script async="async" src="https://consent.trustarc.com/notice?domain=northeastern.edu&c=teconsent&js=nj&noticeType=bb&text=true&gtm=1"></script>
             ';
     });
 }


### PR DESCRIPTION
OVERVIEW

NU is looking at adding the [TrustArc](https://trustarc.com/) cookie consent manager to all websites. This change adds the TrustArc code to this plugin, along with the ability to disable the global, header, footer, or TrustArc code from this plugin's settings page.

DETAILS


`nu_global_elements.php` - Add TrustArc code, and conditionals & settings page  to allow disabling the rendering of the global header, footer, or TrustArc code from this plugin.
`README.md` - Updated with TrustARc and plugin settings info.