### PR TITLE
Namespace wp admin overrides

### DIFF
--- a/manifest/info.json
+++ b/manifest/info.json
@@ -3,7 +3,7 @@
 	"slug" : "global-elements-wordpress",
 	"author" : "<a href='https://its.northeastern.edu/'>ITS Digital Technology & Services</a>",
 	"author_profile" : "https://its.northeastern.edu/",
-	"version" : "1.4.0",
+	"version" : "1.4.1",
 	"download_url" : "https://github.com/ITS-Digital-Technology/global-elements-wordpress/releases/download/v1.4.0/global-elements-wordpress.zip",
 	"requires" : "5.6",
 	"tested" : "6.6.1",

--- a/nu-global-elements-admin.css
+++ b/nu-global-elements-admin.css
@@ -1,34 +1,34 @@
-table.form-table {
+.toplevel_page_nu-global-elements table.form-table {
     max-width: 45rem;
 }
 
-.form-table th {
+.toplevel_page_nu-global-elements .form-table th {
     width: 80%;
 }
 
-.form-table th {
+.toplevel_page_nu-global-elements .form-table th {
     padding-top: 1rem;
 }
 
-.form-table td {
+.toplevel_page_nu-global-elements .form-table td {
     padding-bottom: 2rem;
 }
 
 @media screen and (min-width: 783px) {
-    .form-table td {
+    .toplevel_page_nu-global-elements .form-table td {
         vertical-align: top;
         text-align:center;
     }
 
-    .form-table th,
-    .form-table td {
+    .toplevel_page_nu-global-elements .form-table th,
+    .toplevel_page_nu-global-elements .form-table td {
         padding-top: 1rem;
         padding-bottom: 1rem;
     }
 }
 
-.form-table tr:not(:last-child),
-.form-table tr:not(:last-child) {
+.toplevel_page_nu-global-elements .form-table tr:not(:last-child),
+.toplevel_page_nu-global-elements .form-table tr:not(:last-child) {
     border-bottom: 1px solid rgba(0,0,0,0.3)
 }
 
@@ -40,4 +40,4 @@ table.form-table {
     max-width: 200px;
 }
 
-.sr-only { display: none; }
+.toplevel_page_nu-global-elements .sr-only { display: none; }

--- a/nu_global_elements.php
+++ b/nu_global_elements.php
@@ -10,7 +10,7 @@ Version: 1.4.0
 
 if (!defined('ABSPATH')) { exit; }
 
-const NU_GLOBAL_ELEMENTS_PLUGIN_VER = "1.4.0";
+const NU_GLOBAL_ELEMENTS_PLUGIN_VER = "1.4.1";
 const NU_GLOBAL_ELEMENTS_PLUGIN_MANIFEST_URL = "https://its-digital-technology.github.io/global-elements-wordpress/manifest/info.json";
 
 


### PR DESCRIPTION
Many of the admin style classes in v1.4.0 were not namespaced to the Global Elements plugin and were affecting all wp-admin html table styles.

Tested locally for stability in both Global Elements plugin view and previously affected wp-admin views.

Also, versioned up from 1.4.0 to 1.4.1