### PR TITLE
Feature/automate release deployment

### DIFF
--- a/.github/workflows/build-plugin-release.yml
+++ b/.github/workflows/build-plugin-release.yml
@@ -1,0 +1,218 @@
+name: Build Plugin Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+
+    env:
+      PLUGIN_FILE: nu_global_elements.php
+      PLUGIN_DIR: global-elements-wordpress
+      ZIP_NAME: global-elements-wordpress.zip
+      MANIFEST_TEMPLATE: manifest/info.template.json
+      MANIFEST_OUTPUT: manifest/info.json
+      PAGES_BRANCH: gh-pages
+
+    steps:
+      - name: Check out tagged code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Set release variables
+        shell: bash
+        run: |
+          echo "TAG_NAME=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          echo "LAST_UPDATED=$(date -u '+%Y-%m-%d %H:%M:%S')" >> "$GITHUB_ENV"
+
+      - name: Read plugin header metadata
+        shell: bash
+        run: |
+          set -e
+
+          get_header_value() {
+            local header="$1"
+            grep -i "^${header}:" "$PLUGIN_FILE" | head -n 1 | sed "s/^${header}:[[:space:]]*//I"
+          }
+
+          PLUGIN_NAME=$(get_header_value "Plugin Name")
+          PLUGIN_AUTHOR=$(get_header_value "Author")
+          PLUGIN_AUTHOR_URI=$(get_header_value "Author URI")
+          PLUGIN_VERSION=$(get_header_value "Version")
+          PLUGIN_REQUIRES_AT_LEAST=$(get_header_value "Requires at least")
+          PLUGIN_REQUIRES_PHP=$(get_header_value "Requires PHP")
+
+          echo "PLUGIN_NAME=$PLUGIN_NAME" >> "$GITHUB_ENV"
+          echo "PLUGIN_AUTHOR=$PLUGIN_AUTHOR" >> "$GITHUB_ENV"
+          echo "PLUGIN_AUTHOR_URI=$PLUGIN_AUTHOR_URI" >> "$GITHUB_ENV"
+          echo "PLUGIN_VERSION=$PLUGIN_VERSION" >> "$GITHUB_ENV"
+          echo "PLUGIN_REQUIRES_AT_LEAST=$PLUGIN_REQUIRES_AT_LEAST" >> "$GITHUB_ENV"
+          echo "PLUGIN_REQUIRES_PHP=$PLUGIN_REQUIRES_PHP" >> "$GITHUB_ENV"
+
+      - name: Verify plugin header version matches tag
+        shell: bash
+        run: |
+          echo "Tag version:    $RELEASE_VERSION"
+          echo "Plugin version: $PLUGIN_VERSION"
+
+          if [ -z "$PLUGIN_VERSION" ]; then
+            echo "Could not find Version header in $PLUGIN_FILE"
+            exit 1
+          fi
+
+          if [ "$RELEASE_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "Tag version does not match plugin header version."
+            exit 1
+          fi
+
+      - name: Verify required plugin header fields exist
+        shell: bash
+        run: |
+          set -e
+
+          required_vars=(
+            PLUGIN_NAME
+            PLUGIN_AUTHOR
+            PLUGIN_AUTHOR_URI
+            PLUGIN_REQUIRES_AT_LEAST
+            PLUGIN_REQUIRES_PHP
+          )
+
+          for var_name in "${required_vars[@]}"; do
+            value="${!var_name}"
+            if [ -z "$value" ]; then
+              echo "Missing required plugin header value: $var_name"
+              exit 1
+            fi
+          done
+
+      - name: Build plugin zip with stable top-level folder
+        shell: bash
+        run: |
+          set -e
+
+          rm -rf build "$ZIP_NAME"
+          mkdir -p "build/$PLUGIN_DIR"
+
+          # Build a proper WordPress plugin package with a stable folder name.
+          rsync -av ./ "build/$PLUGIN_DIR/" \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='.gitignore' \
+            --exclude='.nojekyll' \
+            --exclude='.DS_Store' \
+            --exclude='build' \
+            --exclude='manifest' \
+            --exclude='*.zip'
+
+          cd build
+          zip -r "../$ZIP_NAME" "$PLUGIN_DIR"
+
+      - name: Create GitHub release if needed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          if ! gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            gh release create "$TAG_NAME" \
+              --title "$TAG_NAME" \
+              --generate-notes
+          fi
+
+      - name: Upload plugin zip to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh release upload "$TAG_NAME" "$ZIP_NAME" --clobber
+
+      - name: Generate manifest from template and plugin header
+        shell: bash
+        run: |
+          set -e
+
+          python3 - <<'PY'
+          import json
+          import os
+
+          template_path = os.environ["MANIFEST_TEMPLATE"]
+          output_path = os.environ["MANIFEST_OUTPUT"]
+
+          with open(template_path, "r", encoding="utf-8") as f:
+              template = f.read()
+
+          template = template.replace("__VERSION__", os.environ["RELEASE_VERSION"])
+          template = template.replace("__LAST_UPDATED__", os.environ["LAST_UPDATED"])
+
+          data = json.loads(template)
+
+          # Inject canonical plugin metadata from the plugin header.
+          data["name"] = os.environ["PLUGIN_NAME"]
+          data["version"] = os.environ["PLUGIN_VERSION"]
+          data["author"] = f"<a href='{os.environ['PLUGIN_AUTHOR_URI']}'>{os.environ['PLUGIN_AUTHOR']}</a>"
+          data["author_profile"] = os.environ["PLUGIN_AUTHOR_URI"]
+          data["requires"] = os.environ["PLUGIN_REQUIRES_AT_LEAST"]
+          data["requires_php"] = os.environ["PLUGIN_REQUIRES_PHP"]
+
+          with open(output_path, "w", encoding="utf-8") as f:
+              json.dump(data, f, indent=2)
+              f.write("\n")
+          PY
+
+          echo "Generated manifest:"
+          cat "$MANIFEST_OUTPUT"
+
+      - name: Publish manifest to gh-pages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -e
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          rm -rf pages-out
+          mkdir -p pages-out/manifest
+          touch pages-out/.nojekyll
+          cp "$MANIFEST_OUTPUT" pages-out/manifest/info.json
+
+          git fetch origin
+
+          if git ls-remote --exit-code --heads origin "$PAGES_BRANCH" >/dev/null 2>&1; then
+            echo "Updating existing $PAGES_BRANCH branch"
+            git switch --force-create "$PAGES_BRANCH" "origin/$PAGES_BRANCH"
+          else
+            echo "Creating orphan $PAGES_BRANCH branch"
+            git switch --orphan "$PAGES_BRANCH"
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          find . -mindepth 1 -maxdepth 1 \
+            ! -name '.git' \
+            ! -name 'pages-out' \
+            -exec rm -rf {} +
+
+          cp -R pages-out/. .
+
+          git add .nojekyll manifest/info.json
+
+          if git diff --cached --quiet; then
+            echo "No changes to publish to $PAGES_BRANCH"
+          else
+            git commit -m "Publish manifest for $TAG_NAME"
+            git push origin "$PAGES_BRANCH" --force
+          fi

--- a/.github/workflows/build-plugin-release.yml
+++ b/.github/workflows/build-plugin-release.yml
@@ -26,6 +26,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify tag commit is on main
+        shell: bash
+        run: |
+          set -e
+
+          git fetch origin main
+
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/main"; then
+            echo "Tag $GITHUB_REF_NAME is not on a commit reachable from origin/main"
+            exit 1
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -45,7 +57,22 @@ jobs:
 
           get_header_value() {
             local header="$1"
-            grep -i "^${header}:" "$PLUGIN_FILE" | head -n 1 | sed "s/^${header}:[[:space:]]*//I"
+            awk -v IGNORECASE=1 -v key="$header" '
+              {
+                pos = index($0, ":");
+                if (pos > 0) {
+                  field = substr($0, 1, pos - 1);
+                  value = substr($0, pos + 1);
+                  gsub(/^[[:space:]]+|[[:space:]]+$/, "", field);
+                  gsub(/^[[:space:]]+|[[:space:]]+$/, "", value);
+
+                  if (tolower(field) == tolower(key)) {
+                    print value;
+                    exit;
+                  }
+                }
+              }
+            ' "$PLUGIN_FILE"
           }
 
           PLUGIN_NAME=$(get_header_value "Plugin Name")
@@ -214,5 +241,8 @@ jobs:
             echo "No changes to publish to $PAGES_BRANCH"
           else
             git commit -m "Publish manifest for $TAG_NAME"
+
+            # Force-push is intentional here because gh-pages is treated as a
+            # generated output branch, not a manually maintained source branch.
             git push origin "$PAGES_BRANCH" --force
           fi

--- a/manifest/info.template.json
+++ b/manifest/info.template.json
@@ -1,0 +1,15 @@
+{
+	"slug" : "global-elements-wordpress",
+	"download_url" : "https://github.com/ITS-Digital-Technology/global-elements-wordpress/releases/download/v__VERSION__/global-elements-wordpress.zip",
+	"tested" : "6.9.4",
+	"last_updated" : "__LAST_UPDATED__",
+	"sections" : {
+		"description" : "A Wordpress plugin developed by the Northeastern University ITS Web Solutions team that inserts the Northeastern University global header, footer, and TrustArc cookie consent manager. Each elemenent can be enabled/disabled from the plugin's settings.",
+		"installation" : "Click the activate button to install. In order for the global header to display, the active theme must support a call to wp_body_open() after the opening &lt;body&gt; tag.",
+		"changelog" : "See the GitHub release notes for this version."
+	},
+	"banners" : {
+		"low" : "",
+		"high" : ""
+	}
+}

--- a/nu-global-elements-admin.css
+++ b/nu-global-elements-admin.css
@@ -4,9 +4,6 @@
 
 .toplevel_page_nu-global-elements .form-table th {
     width: 80%;
-}
-
-.toplevel_page_nu-global-elements .form-table th {
     padding-top: 1rem;
 }
 
@@ -17,7 +14,7 @@
 @media screen and (min-width: 783px) {
     .toplevel_page_nu-global-elements .form-table td {
         vertical-align: top;
-        text-align:center;
+        text-align: center;
     }
 
     .toplevel_page_nu-global-elements .form-table th,
@@ -27,17 +24,18 @@
     }
 }
 
-.toplevel_page_nu-global-elements .form-table tr:not(:last-child),
 .toplevel_page_nu-global-elements .form-table tr:not(:last-child) {
-    border-bottom: 1px solid rgba(0,0,0,0.3)
+    border-bottom: 1px solid rgba(0, 0, 0, 0.3);
 }
 
 .nuge-img-max-width {
-    max-width :300px;
+    max-width: 300px;
 }
 
 .nuge-skip-link-selector {
     max-width: 200px;
 }
 
-.toplevel_page_nu-global-elements .sr-only { display: none; }
+.toplevel_page_nu-global-elements .sr-only {
+    display: none;
+}

--- a/nu_global_elements.php
+++ b/nu_global_elements.php
@@ -1,17 +1,43 @@
 <?php
-/* 
+/*
 Plugin Name: Northeastern Global Elements
 Plugin URI: https://github.com/ITS-Digital-Technology/global-elements-wordpress
 Description: Inserts the Northeastern University global header, footer, and TrustArc cookie consent manager. Requires wp_body_open() under the body tag to display the global header.
+Version: 1.4.1
+Requires at least: 6.0
+Requires PHP: 7.4
 Author: Northeastern University ITS Web Solutions
 Author URI: https://its.northeastern.edu
-Version: 1.4.1
-*/ 
+Update URI: https://github.com/ITS-Digital-Technology/global-elements-wordpress
+*/
 
 if (!defined('ABSPATH')) { exit; }
 
-const NU_GLOBAL_ELEMENTS_PLUGIN_VER = "1.4.1";
 const NU_GLOBAL_ELEMENTS_PLUGIN_MANIFEST_URL = "https://its-digital-technology.github.io/global-elements-wordpress/manifest/info.json";
+
+function nu_global_elements_plugin_version() {
+	static $version = null;
+
+	if ( null !== $version ) {
+		return $version;
+	}
+
+	if ( ! function_exists( 'get_file_data' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$plugin_data = get_file_data(
+		__FILE__,
+		array(
+			'Version' => 'Version',
+		),
+		'plugin'
+	);
+
+	$version = isset( $plugin_data['Version'] ) ? trim( $plugin_data['Version'] ) : '';
+
+	return $version;
+}
 
 /** 
  * Get options values for plugin
@@ -344,16 +370,18 @@ if( ! class_exists( 'UpdateChecker' ) ) {
 	class UpdateChecker{
 
 		public $plugin_slug;
+		public $plugin_file;
 		public $version;
 		public $cache_key;
 		public $cache_allowed;
 
 		public function __construct() {
 
-			$this->plugin_slug = plugin_basename( __DIR__ );
-			$this->version = NU_GLOBAL_ELEMENTS_PLUGIN_VER;
+			$this->plugin_file = plugin_basename( __FILE__ );
+			$this->plugin_slug = dirname( $this->plugin_file );
+			$this->version = nu_global_elements_plugin_version();
 			$this->cache_key = 'global_elements_updater';
-			$this->cache_allowed = false;
+			$this->cache_allowed = true;
 
 			add_filter( 'plugins_api', array( $this, 'info' ), 20, 3 );
 			add_filter( 'site_transient_update_plugins', array( $this, 'update' ) );
@@ -385,7 +413,7 @@ if( ! class_exists( 'UpdateChecker' ) ) {
 					return false;
 				}
 
-				set_transient( $this->cache_key, $remote, DAY_IN_SECONDS );
+				set_transient( $this->cache_key, $remote, 12 * HOUR_IN_SECONDS );
 
 			}
 
@@ -396,7 +424,7 @@ if( ! class_exists( 'UpdateChecker' ) ) {
 		}
 
 
-		function info( $res, $action, $args ) {
+		public function info( $res, $action, $args ) {
 
 			// do nothing if you're not getting plugin information right now
 			if( 'plugin_information' !== $action ) {
@@ -404,7 +432,7 @@ if( ! class_exists( 'UpdateChecker' ) ) {
 			}
 
 			// do nothing if it is not our plugin
-			if( $this->plugin_slug !== $args->slug ) {
+			if( empty( $args->slug ) || $this->plugin_slug !== $args->slug ) {
 				return $res;
 			}
 
@@ -448,31 +476,29 @@ if( ! class_exists( 'UpdateChecker' ) ) {
 
 		public function update( $transient ) {
 
-			if ( empty($transient->checked ) ) {
+			if ( empty( $transient->checked ) ) {
 				return $transient;
 			}
 
 			$remote = $this->request();
 
-			if(
+			if (
 				$remote
 				&& version_compare( $this->version, $remote->version, '<' )
 				&& version_compare( $remote->requires, get_bloginfo( 'version' ), '<=' )
-				&& version_compare( $remote->requires_php, PHP_VERSION, '<' )
+				&& version_compare( $remote->requires_php, PHP_VERSION, '<=' )
 			) {
 				$res = new stdClass();
 				$res->slug = $this->plugin_slug;
-				$res->plugin = plugin_basename( __FILE__ ); 
+				$res->plugin = $this->plugin_file;
 				$res->new_version = $remote->version;
 				$res->tested = $remote->tested;
 				$res->package = $remote->download_url;
 
 				$transient->response[ $res->plugin ] = $res;
-
-	    }
+			}
 
 			return $transient;
-
 		}
 
 		public function purge( $upgrader, $options ){

--- a/nu_global_elements.php
+++ b/nu_global_elements.php
@@ -3,7 +3,7 @@
 Plugin Name: Northeastern Global Elements
 Plugin URI: https://github.com/ITS-Digital-Technology/global-elements-wordpress
 Description: Inserts the Northeastern University global header, footer, and TrustArc cookie consent manager. Requires wp_body_open() under the body tag to display the global header.
-Version: 1.4.1
+Version: 1.5.0
 Requires at least: 6.0
 Requires PHP: 7.4
 Author: Northeastern University ITS Web Solutions


### PR DESCRIPTION
## Automate plugin releases and simplify update metadata for `global-elements-wordpress`

### Description

This PR improves the release and update flow for the Northeastern Global Elements plugin by reducing manual version definition, automating release packaging, and moving the public update manifest to a more predictable GitHub Pages publishing model.

It also tightens the plugin’s custom updater logic and includes minor CSS cleanup.

### What changed

### Plugin metadata and updater
- Removed the hard-coded PHP version constant and now derive the plugin version from the plugin header, making the header the canonical source of truth for versioning.
- Updated the custom updater to use explicit `plugin_file` and `plugin_slug` values derived from the installed plugin path.
- Enabled transient caching for remote manifest requests with a 12-hour cache window.
- Added a safer slug check in the plugin info handler.
- Updated the plugin metadata flow so release metadata can be derived from the plugin header rather than duplicated in multiple places.

#### Release automation
- Added the `build-plugin-release` GitHub Actions workflow to run on version tags (`v*`).
- The workflow now:
  - verifies the plugin header version matches the tag
  - reads canonical metadata from the plugin header
  - builds a proper WordPress plugin zip with a stable top-level `global-elements-wordpress/` folder
  - creates/uploads the release asset automatically
  - generates `manifest/info.json` from `manifest/info.template.json`
  - publishes the generated manifest and `.nojekyll` to the `gh-pages` branch for GitHub Pages hosting

#### Manifest changes
- Introduced `manifest/info.template.json` as the editable source template.
- Reduced duplication by generating manifest fields like version, author, author profile, minimum WP version, and minimum PHP version from the plugin header during release.
- Kept manifest-specific fields like `tested`, `sections`, `banners`, and `last_updated` in the generated updater payload.

#### Admin CSS
- Cleaned up a couple of redundant selectors/rules while preserving the current behavior.

### Why

Previously, releases depended on manual zip creation/upload and a manually updated manifest, which created multiple opportunities for version mismatches and packaging mistakes.

This PR makes releases more repeatable and ensures the updater metadata is generated consistently from the plugin’s actual source metadata instead of being maintained in several places by hand.

### Release flow after this PR

1. Update the plugin header version in `nu_global_elements.php`
2. Merge to `main`
3. Create and push a version tag like `v1.4.2`
4. GitHub Actions builds the plugin zip, uploads it to the release, generates the manifest, and publishes it to `gh-pages`

### Notes

- GitHub Pages should be configured to publish from the `gh-pages` branch root for the public manifest URL to reflect the new workflow.
- The release zip now intentionally excludes repo-only artifacts like the manifest source/template and Pages-only files.

### Testing

I've tested the plugin again locally to make sure no breaking changes have been introduced. We'll also need to test this new workflow by tagging the new release and pushing it to origin/main.