### PR TITLE
Tweak release deployment - change info.json location to temp path

### DIFF
--- a/.github/workflows/build-plugin-release.yml
+++ b/.github/workflows/build-plugin-release.yml
@@ -17,7 +17,6 @@ jobs:
       PLUGIN_DIR: global-elements-wordpress
       ZIP_NAME: global-elements-wordpress.zip
       MANIFEST_TEMPLATE: manifest/info.template.json
-      MANIFEST_OUTPUT: manifest/info.json
       PAGES_BRANCH: gh-pages
 
     steps:
@@ -25,6 +24,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Set manifest output path
+        shell: bash
+        run: |
+          echo "MANIFEST_OUTPUT=$RUNNER_TEMP/info.json" >> "$GITHUB_ENV"
 
       - name: Verify tag commit is on main
         shell: bash
@@ -242,7 +246,7 @@ jobs:
           else
             git commit -m "Publish manifest for $TAG_NAME"
 
-            # Force-push is intentional here because gh-pages is treated as a
+            # Force-push is intentional because gh-pages is treated as a
             # generated output branch, not a manually maintained source branch.
             git push origin "$PAGES_BRANCH" --force
           fi


### PR DESCRIPTION
## Description

This PR updates the plugin release workflow to fix initial `gh-pages` publishing issues and make manifest generation/publishing more reliable.

## What changed

- Updated the workflow to write the generated manifest to the runner temp directory instead of the checked-out repo, avoiding branch-switch failures caused by local modifications to `manifest/info.json`

## Why

The first workflow test failed when the job generated `manifest/info.json` inside the checked-out repository and then attempted to switch to `gh-pages`. Git correctly refused to switch branches because the tracked file had local changes.

This update moves the generated manifest out of the repo working tree during the build, which avoids that conflict and allows the workflow to create or update `gh-pages` cleanly.

## Notes

- This change does not alter the plugin updater logic itself; it only fixes and hardens the release workflow. It's possible more changes will be needed as we test.