### PR TITLE
Feature/automate release deployment

### DIFF
--- a/.github/workflows/build-plugin-release.yml
+++ b/.github/workflows/build-plugin-release.yml
@@ -147,6 +147,7 @@ jobs:
             --exclude='.DS_Store' \
             --exclude='build' \
             --exclude='manifest' \
+            --exclude='development-release-notes.md' \
             --exclude='*.zip'
 
           cd build

--- a/.github/workflows/build-plugin-release.yml
+++ b/.github/workflows/build-plugin-release.yml
@@ -170,6 +170,13 @@ jobs:
         run: |
           gh release upload "$TAG_NAME" "$ZIP_NAME" --clobber
 
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh release edit "$TAG_NAME" --draft=false
+
       - name: Generate manifest from template and plugin header
         shell: bash
         run: |

--- a/development-release-notes.md
+++ b/development-release-notes.md
@@ -1,0 +1,63 @@
+# Development / Release Notes
+
+This plugin’s release process is automated through GitHub Actions.
+
+## Release process
+
+1. Make changes on a feature branch
+2. Update the plugin header version in `nu_global_elements.php`
+3. Create a PR, then merge the feature branch into `main`
+4. Create and push a version tag such as:
+
+   ```bash
+   git tag -a v1.5.1 -m "Patch version 1.5.1"
+   git push origin v1.5.1
+   ```
+
+5. The release workflow will then:
+   - verify that the tag points to a commit reachable from `main`
+   - verify that the plugin header version matches the tag version
+   - build `global-elements-wordpress.zip` with a stable top-level plugin folder
+   - create or update the GitHub release for that tag
+   - upload the packaged plugin zip to the release
+   - generate the public updater manifest from `manifest/info.template.json`
+   - publish the generated manifest to the `gh-pages` branch
+
+## Plugin metadata
+
+The plugin header in `nu_global_elements.php` is the canonical source of truth for release metadata used by the workflow, including:
+
+- plugin name
+- version
+- author
+- author URI
+- minimum supported WordPress version
+- minimum supported PHP version
+
+Update the plugin header before tagging a release.
+
+## Manifest publishing
+
+The updater manifest is published at:
+
+```text
+https://its-digital-technology.github.io/global-elements-wordpress/manifest/info.json
+```
+
+It is generated during the release workflow from `manifest/info.template.json`.
+
+## GitHub Pages configuration
+
+GitHub Pages should be configured to publish from:
+
+- **Source:** Deploy from a branch
+- **Branch:** `gh-pages`
+- **Folder:** `/ (root)`
+
+The release workflow updates the `gh-pages` branch automatically. It is treated as generated output and should not be edited manually.
+
+## Notes
+
+- Do not commit release-only work directly to `main`.
+- The packaged plugin zip intentionally excludes repo-only artifacts such as workflow files, manifest source files, and Pages-only files.
+- The workflow force-pushes `gh-pages` intentionally because it is treated as generated output.

--- a/development-release-notes.md
+++ b/development-release-notes.md
@@ -4,10 +4,10 @@ This plugin’s release process is automated through GitHub Actions, specificall
 
 ## Release process
 
-1. Make changes on a feature branch
-2. Update the plugin header version in `nu_global_elements.php`
+1. Create a new feature branch off `main` and make changes.
+2. Update the plugin header version in `nu_global_elements.php`.
 3. Create a PR, then merge the feature branch into `main`
-4. Create and push a new version tag on main such as:
+4. Create and push a new version tag from `main`, such as:
 
    ```bash
    git tag -a v1.5.1 -m "Patch version 1.5.1"
@@ -17,11 +17,17 @@ This plugin’s release process is automated through GitHub Actions, specificall
 5. The release workflow will then:
    - verify that the tag points to a commit reachable from `main`
    - verify that the plugin header version matches the tag version
-   - build `global-elements-wordpress.zip` with a stable top-level plugin folder
+   - build `global-elements-wordpress.zip` with a stable top-level plugin folder name
    - create or update the GitHub release for that tag
    - upload the packaged plugin zip to the release
-   - generate the public updater manifest from `manifest/info.template.json`
+   - generate the public updater manifest from metadata in the header of `nu_global_elements.php`, using `manifest/info.template.json` as a template
    - publish the generated manifest to the `gh-pages` branch
+
+6. GitHub Pages then serves the updated manifest from the `gh-pages` branch at: 
+
+   ```text
+   https://its-digital-technology.github.io/global-elements-wordpress/manifest/info.json
+   ```
 
 ## Plugin metadata
 
@@ -34,17 +40,7 @@ The plugin header in `nu_global_elements.php` is the canonical source of truth f
 - minimum supported WordPress version
 - minimum supported PHP version
 
-Update the plugin header before tagging a release.
-
-## Manifest publishing
-
-The updater manifest is published at:
-
-```text
-https://its-digital-technology.github.io/global-elements-wordpress/manifest/info.json
-```
-
-It is generated during the release workflow from `manifest/info.template.json`.
+Update the plugin header BEFORE tagging a release.
 
 ## GitHub Pages configuration
 

--- a/development-release-notes.md
+++ b/development-release-notes.md
@@ -1,13 +1,13 @@
 # Development / Release Notes
 
-This plugin’s release process is automated through GitHub Actions, specifically `.github/workflows/build-plugin-release.yml`, and is triggered by pushing a version tag such as `v1.5.1`.
+This plugin’s release process is automated through GitHub Actions, specifically `.github/workflows/build-plugin-release.yml`, and is triggered by pushing a new version tag such as `v1.5.1`.
 
 ## Release process
 
 1. Make changes on a feature branch
 2. Update the plugin header version in `nu_global_elements.php`
 3. Create a PR, then merge the feature branch into `main`
-4. Create and push a version tag such as:
+4. Create and push a new version tag on main such as:
 
    ```bash
    git tag -a v1.5.1 -m "Patch version 1.5.1"

--- a/development-release-notes.md
+++ b/development-release-notes.md
@@ -1,6 +1,6 @@
 # Development / Release Notes
 
-This plugin’s release process is automated through GitHub Actions.
+This plugin’s release process is automated through GitHub Actions, specifically `.github/workflows/build-plugin-release.yml`, and is triggered by pushing a version tag such as `v1.5.1`.
 
 ## Release process
 
@@ -58,6 +58,6 @@ The release workflow updates the `gh-pages` branch automatically. It is treated 
 
 ## Notes
 
-- Do not commit release-only work directly to `main`.
+- Do not commit changes directly to `main`.
 - The packaged plugin zip intentionally excludes repo-only artifacts such as workflow files, manifest source files, and Pages-only files.
 - The workflow force-pushes `gh-pages` intentionally because it is treated as generated output.

--- a/manifest/info.template.json
+++ b/manifest/info.template.json
@@ -4,7 +4,7 @@
 	"tested" : "6.9.4",
 	"last_updated" : "__LAST_UPDATED__",
 	"sections" : {
-		"description" : "A Wordpress plugin developed by the Northeastern University ITS Web Solutions team that inserts the Northeastern University global header, footer, and TrustArc cookie consent manager. Each elemenent can be enabled/disabled from the plugin's settings.",
+		"description" : "A WordPress plugin developed by the Northeastern University ITS Web Solutions team that inserts the Northeastern University global header, footer, and TrustArc cookie consent manager. Each element can be enabled/disabled from the plugin's settings.",
 		"installation" : "Click the activate button to install. In order for the global header to display, the active theme must support a call to wp_body_open() after the opening &lt;body&gt; tag.",
 		"changelog" : "See the GitHub release notes for this version."
 	},

--- a/nu_global_elements.php
+++ b/nu_global_elements.php
@@ -3,7 +3,7 @@
 Plugin Name: Northeastern Global Elements
 Plugin URI: https://github.com/ITS-Digital-Technology/global-elements-wordpress
 Description: Inserts the Northeastern University global header, footer, and TrustArc cookie consent manager. Requires wp_body_open() under the body tag to display the global header.
-Version: 1.5.0
+Version: 1.5.1
 Requires at least: 6.0
 Requires PHP: 7.4
 Author: Northeastern University ITS Web Solutions


### PR DESCRIPTION
## Description

This PR updates the release workflow to explicitly publish the GitHub release after uploading the packaged plugin zip, and adds development release notes.

## What changed

- Added a `Publish release` step to the `Build Plugin Release` workflow.
- The new step runs `gh release edit "$TAG_NAME" --draft=false` after the zip asset is uploaded.
- Added `development-release-notes.md` to document how the new release process works.
- Fixed minor typos in `manifest/info.template.json`.

## Why

During testing, the workflow successfully created the release asset and published the manifest to `gh-pages`, but the asset URL was not resolving to the expected tagged release path.

Instead of a predictable URL like:

`/releases/download/v1.5.0/global-elements-wordpress.zip`

the uploaded asset was associated with an `untagged-...` path because the release was still in draft state.

Explicitly publishing the release after upload ensures the release asset is associated with the final tagged release and gets a stable, predictable download URL for the updater manifest.

## Notes

- This is a small workflow-only follow-up to the main release automation work
- The new step happens before manifest generation so the manifest is built against the final published release state