### PR TITLE
Fixed multisite bug which disallowed an initial save of a NU Wordmark change without changing it twice. 

### DIFF
--- a/nu_global_elements.php
+++ b/nu_global_elements.php
@@ -3,7 +3,7 @@
 Plugin Name: Northeastern Global Elements
 Plugin URI: https://github.com/ITS-Digital-Technology/global-elements-wordpress
 Description: Inserts the Northeastern University global header, footer, and TrustArc cookie consent manager. Requires wp_body_open() under the body tag to display the global header.
-Version: 1.6.0
+Version: 1.6.1
 Requires at least: 6.0
 Requires PHP: 7.4
 Author: Northeastern University ITS Web Solutions
@@ -304,7 +304,7 @@ class NUGlobalElements {
 		 * not set at all, the front-end will check if the site is hosted on
 		 * CampusPress to determine the default Wordmark setting.
 		 */ 
-		if ( isset( $input['show_nu_wordmark'] ) ) {
+		if ( isset( $input['show_nu_wordmark'] ) && $input['show_nu_wordmark'] === 'show_nu_wordmark' ) {
             $sanitary_values['show_nu_wordmark'] = 'show_nu_wordmark';
         } else {
             $sanitary_values['show_nu_wordmark'] = '0';


### PR DESCRIPTION
### Description
Resolved a multisite environment bug that required users to save the NU Wordmark setting twice for it to take effect. After saving twice initially, the setting could then be saved once normally thereafter.

The bug fix will allow the NU Wordmark setting to be changed normally without having to save it twice initially.

### What changed:
The sanitize callback, `nu_global_elements_sanitize` for the NU Wordmark was not strictly validating the incoming value, causing it to incorrectly overwrite a saved OFF state back to ON.

The sanitize callback is now strictly validating the incoming value. In a multisite, the sanitize callback can be invoked more than once, and on the second call it would incorrectly overwrite a saved OFF state ('0') back to ON ('`show_nu_wordmark`').

### QA Testing:

This change was tested in the following test environments:

- Locally
- CampusPress DEV: https://sites-dev.northeastern.edu/
- WP Engine DEV: https://nudvbachcomp24.wpenginepowered.com/, https://nudvgrad2024.wpenginepowered.com/

